### PR TITLE
Fix associativity of power, unary

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ Expressions:
     term        → factor ( ( "-" | "+" ) factor )*
     factor      → unary ( ( "/" | "*" ) unary )*
     unary       → ( "!" | "-" | "++" | "--" ) unary
+                | postfix ;
+    postfix     → primary ( "++" | "--" )* 
                 | exponent ;
-    exponent    → (postfix "**" unary)
-                | postfix
-    postfix     → primary ( "++" | "--" )* | call ;
+    exponent    → (call "**" unary)
+                | call ; 
     call        → primary ( "(" arguments? ")" | "." IDENTIFIER )* ;
     primary     → "true" | "false" | "none" | "this"
                 | NUMBER | STRING | IDENTIFIER | "(" expression ")"
@@ -103,9 +104,9 @@ Currently continue statement does not work as expected for for loops, incremento
 
     Name	      Operators	               Associates
     Call          a()                      Left
+    Exponent      **                       Right
     Postfix       a++ a--                  Left
     Unary	      ! - ++a --a              Right
-    Exponent      **                       Left
     Factor	      / *                      Left
     Term	      - +                      Left
     Comparison    > >= < <=	               Left

--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ Expressions:
     term        → factor ( ( "-" | "+" ) factor )*
     factor      → unary ( ( "/" | "*" ) unary )*
     unary       → ( "!" | "-" | "++" | "--" ) unary
+                | exponent ;
+    exponent    → (prefix "**" unary)
+                | prefix ;
+    prefix      → ("++" | "--") primary
                 | postfix ;
     postfix     → primary ( "++" | "--" )* 
-                | exponent ;
-    exponent    → (call "**" unary)
                 | call ; 
     call        → primary ( "(" arguments? ")" | "." IDENTIFIER )* ;
     primary     → "true" | "false" | "none" | "this"
@@ -104,9 +106,10 @@ Currently continue statement does not work as expected for for loops, incremento
 
     Name	      Operators	               Associates
     Call          a()                      Left
-    Exponent      **                       Right
     Postfix       a++ a--                  Left
-    Unary	      ! - ++a --a              Right
+    Prefix        ++a --a                  Right
+    Exponent      **                       Right
+    Unary	      ! -                      Right
     Factor	      / *                      Left
     Term	      - +                      Left
     Comparison    > >= < <=	               Left

--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Expressions:
     equality    → comparison ( ( "!=" | "==" ) comparison )*
     comparison  → term ( ( ">" | ">=" | "<" | "<=" ) term )*
     term        → factor ( ( "-" | "+" ) factor )*
-    factor      → exponent ( ( "/" | "*" ) exponent )*
-    exponent    → unary ( ( "**" ) unary )*
+    factor      → unary ( ( "/" | "*" ) unary )*
     unary       → ( "!" | "-" | "++" | "--" ) unary
-                | postfix ;
+                | exponent ;
+    exponent    → (postfix "**" unary)
+                | postfix
     postfix     → primary ( "++" | "--" )* | call ;
     call        → primary ( "(" arguments? ")" | "." IDENTIFIER )* ;
     primary     → "true" | "false" | "none" | "this"

--- a/src/com/company/fail/Parser.java
+++ b/src/com/company/fail/Parser.java
@@ -435,9 +435,31 @@ class Parser {
     }
 
     private Expr unary() {
-        if (match(BANG, MINUS, PLUS_PLUS, MINUS_MINUS)) {
+        if (match(BANG, MINUS)) {
             Token operator = previous();
             Expr right = unary();
+            return new Expr.Unary(operator, right, false);
+        }
+
+        return exponent();
+    }
+
+    private Expr exponent() {
+        Expr expr = prefix();
+
+        if (match(STAR_STAR)) {
+            Token operator = previous();
+            Expr right = unary();
+            return new Expr.Binary(expr, operator, right);
+        }
+
+        return expr;
+    }
+
+    private Expr prefix() {
+        if (match(PLUS_PLUS, MINUS_MINUS)) {
+            Token operator = previous();
+            Expr right = primary();
             return new Expr.Unary(operator, right, false);
         }
 
@@ -453,19 +475,7 @@ class Parser {
             return new Expr.Unary(operator, left, true);
         }
 
-        return exponent();
-    }
-
-    private Expr exponent() {
-        Expr expr = call();
-
-        while (match(STAR_STAR)) {
-            Token operator = previous();
-            Expr right = unary();
-            return new Expr.Binary(expr, operator, right);
-        }
-
-        return expr;
+        return call();
     }
 
     private Expr call() {

--- a/src/com/company/fail/Parser.java
+++ b/src/com/company/fail/Parser.java
@@ -441,19 +441,7 @@ class Parser {
             return new Expr.Unary(operator, right, false);
         }
 
-        return exponent();
-    }
-
-    private Expr exponent() {
-        Expr expr = postfix();
-
-        while (match(STAR_STAR)) {
-            Token operator = previous();
-            Expr right = unary();
-            return new Expr.Binary(expr, operator, right);
-        }
-
-        return expr;
+        return postfix();
     }
 
     private Expr postfix() {
@@ -465,7 +453,19 @@ class Parser {
             return new Expr.Unary(operator, left, true);
         }
 
-        return call();
+        return exponent();
+    }
+
+    private Expr exponent() {
+        Expr expr = call();
+
+        while (match(STAR_STAR)) {
+            Token operator = previous();
+            Expr right = unary();
+            return new Expr.Binary(expr, operator, right);
+        }
+
+        return expr;
     }
 
     private Expr call() {

--- a/src/com/company/fail/Parser.java
+++ b/src/com/company/fail/Parser.java
@@ -423,21 +423,9 @@ class Parser {
     }
 
     private Expr factor() {
-        Expr expr = exponent();
-
-        while (match(SLASH, STAR)) {
-            Token operator = previous();
-            Expr right = exponent();
-            expr = new Expr.Binary(expr, operator, right);
-        }
-
-        return expr;
-    }
-
-    private Expr exponent() {
         Expr expr = unary();
 
-        while (match(STAR_STAR)) {
+        while (match(SLASH, STAR)) {
             Token operator = previous();
             Expr right = unary();
             expr = new Expr.Binary(expr, operator, right);
@@ -453,7 +441,19 @@ class Parser {
             return new Expr.Unary(operator, right, false);
         }
 
-        return postfix();
+        return exponent();
+    }
+
+    private Expr exponent() {
+        Expr expr = postfix();
+
+        while (match(STAR_STAR)) {
+            Token operator = previous();
+            Expr right = unary();
+            return new Expr.Binary(expr, operator, right);
+        }
+
+        return expr;
     }
 
     private Expr postfix() {


### PR DESCRIPTION
This should fix associativity issues with exponentiation. 2^2^4 = 65536.

A few extra additions: 

- -2^2=-4, which should be correct according to order of operations.
- Calling unary as the for the right expression in exponent allows for expressions like 2^-2 to be evaluated.

I also updated the readme to add my additions to the grammar.

I hope you decide to add this!

Should fix #7 